### PR TITLE
Add support for stripping out -equiv units

### DIFF
--- a/changelog/26.improvement.md
+++ b/changelog/26.improvement.md
@@ -1,0 +1,1 @@
+Adds `-equiv` to the set of strings that are incompatible with `pint` and stripped out.

--- a/src/gcages/units_helpers.py
+++ b/src/gcages/units_helpers.py
@@ -10,10 +10,10 @@ import pandas as pd
 
 
 def assert_has_no_pint_incompatible_characters(
-    units: Collection[str], pint_incompatible_characters: Collection[str] = {"-"}
+    units: Collection[str], pint_incompatible_characters=None
 ) -> None:
     """
-    Assert that a collection does not contain pint-incompatible characters
+    Assert that a collection does not contain pint-incompatible characters/strings
 
     Parameters
     ----------
@@ -25,6 +25,9 @@ def assert_has_no_pint_incompatible_characters(
     pint_incompatible_characters
         Characters which are incompatible with pint
 
+        This defaults to `{"-", "equiv"}`, which are commonly used in units,
+        but not compatible with pint.
+
         You should not need to change this, but it is made an argument just in case
 
     Raises
@@ -32,6 +35,9 @@ def assert_has_no_pint_incompatible_characters(
     AssertionError
         `units` has elements that contain pint-incompatible characters
     """
+    if pint_incompatible_characters is None:
+        pint_incompatible_characters = {"-", "equiv"}
+
     unit_contains_pint_incompatible = [
         u for u in units if any(pi in u for pi in pint_incompatible_characters)
     ]
@@ -39,7 +45,8 @@ def assert_has_no_pint_incompatible_characters(
         msg = (
             "The following units contain pint incompatible characters: "
             f"{unit_contains_pint_incompatible=}. "
-            f"{pint_incompatible_characters=}"
+            # Sort to make the error message deterministic
+            f"pint_incompatible_characters={sorted(pint_incompatible_characters)}"
         )
         raise AssertionError(msg)
 
@@ -58,7 +65,7 @@ def strip_pint_incompatible_characters_from_unit_string(unit_str: str) -> str:
     :
         `unit_str` with pint-incompatible characters removed
     """
-    return unit_str.replace("-", "")
+    return unit_str.replace("-", "").replace("equiv", "")
 
 
 def strip_pint_incompatible_characters_from_units(

--- a/tests/integration/test_units_helpers.py
+++ b/tests/integration/test_units_helpers.py
@@ -31,25 +31,31 @@ def test_strip_pint_incompatible_characters_from_units(
     if units_index_level is not None:
         units_index_level_exp = "unit"
 
+    index_data = [
+        ("sa", "CO2", "MtCO2 / yr"),
+        ("sb", "CO2", "MtCO2 / yr"),
+        ("sa", "hfc4310-mee", "MtHFC4310-mee / yr"),
+        ("sb", "hfc4310-mee", "MtHFC4310-mee / yr"),
+        ("sa", "hfc-125", "kt HFC-125/yr"),
+        ("sb", "hfc-125", "kt HFC-125/yr"),
+        ("sa", "hfc134a-equiv", "kt HFC134a-equiv/yr"),
+    ]
+    time_steps = [2010, 2020, 2050]
+
     start = pd.DataFrame(
-        np.arange(18).reshape((6, 3)),
-        columns=[2010, 2020, 2050],
+        np.arange(len(index_data) * len(time_steps)).reshape(
+            (len(index_data), len(time_steps))
+        ),
+        columns=time_steps,
         index=pd.MultiIndex.from_tuples(
-            [
-                ("sa", "CO2", "MtCO2 / yr"),
-                ("sb", "CO2", "MtCO2 / yr"),
-                ("sa", "hfc4310-mee", "MtHFC4310-mee / yr"),
-                ("sb", "hfc4310-mee", "MtHFC4310-mee / yr"),
-                ("sa", "hfc-125", "kt HFC-125/yr"),
-                ("sb", "hfc-125", "kt HFC-125/yr"),
-            ],
+            index_data,
             names=["scenario", "variable", units_index_level_exp],
         ),
     )
 
     res = strip_pint_incompatible_characters_from_units(start, **kwargs)
 
-    exp_units = {"MtCO2 / yr", "MtHFC4310mee / yr", "kt HFC125/yr"}
+    exp_units = {"MtCO2 / yr", "MtHFC4310mee / yr", "kt HFC125/yr", "kt HFC134a/yr"}
     assert (
         set(res.index.get_level_values(units_index_level_exp).unique().tolist())
         == exp_units
@@ -60,7 +66,7 @@ def test_assert_has_no_pint_incompatible_characters():
     error_msg = re.escape(
         "The following units contain pint incompatible characters: "
         "unit_contains_pint_incompatible=['Mt HFC43-10/yr']. "
-        "pint_incompatible_characters={'-'}"
+        "pint_incompatible_characters=['-', 'equiv']"
     )
     with pytest.raises(AssertionError, match=error_msg):
         assert_has_no_pint_incompatible_characters(


### PR DESCRIPTION
## Description

Some units strings include `-equiv` in them, which is incompatible with Pint.
This adds that to the list of incompatible characters.

The moniker "pint-incompatible characters" is slightly outdated, but it's not worth changing the API IMHO

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
