### PR TITLE
Update emissions_variables with RCMIP3 values

### DIFF
--- a/src/gcages/databases/emissions_variables.csv
+++ b/src/gcages/databases/emissions_variables.csv
@@ -1,54 +1,54 @@
-gcages,openscm_runner,iamc,cmip7_scenariomip,rcmip,ar6_cfc_infilling_db
-Emissions|BC,Emissions|BC,Emissions|BC,Emissions|BC,Emissions|BC,Emissions|BC
-Emissions|C2F6,Emissions|C2F6,Emissions|PFC|C2F6,Emissions|C2F6,Emissions|F-Gases|PFC|C2F6,Emissions|PFC|C2F6
-Emissions|C3F8,Emissions|C3F8,Emissions|PFC|C3F8,Emissions|C3F8,Emissions|F-Gases|PFC|C3F8,Emissions|PFC|C3F8
-Emissions|C4F10,Emissions|C4F10,Emissions|PFC|C4F10,Emissions|C4F10,Emissions|F-Gases|PFC|C4F10,Emissions|PFC|C4F10
-Emissions|C5F12,Emissions|C5F12,Emissions|PFC|C5F12,Emissions|C5F12,Emissions|F-Gases|PFC|C5F12,Emissions|PFC|C5F12
-Emissions|C6F14,Emissions|C6F14,Emissions|PFC|C6F14,Emissions|C6F14,Emissions|F-Gases|PFC|C6F14,Emissions|PFC|C6F14
-Emissions|C7F16,Emissions|C7F16,Emissions|PFC|C7F16,Emissions|C7F16,Emissions|F-Gases|PFC|C7F16,Emissions|PFC|C7F16
-Emissions|C8F18,Emissions|C8F18,Emissions|PFC|C8F18,Emissions|C8F18,Emissions|F-Gases|PFC|C8F18,Emissions|PFC|C8F18
-Emissions|CF4,Emissions|CF4,Emissions|PFC|CF4,Emissions|CF4,Emissions|F-Gases|PFC|CF4,Emissions|PFC|CF4
-Emissions|CH4,Emissions|CH4,Emissions|CH4,Emissions|CH4,Emissions|CH4,Emissions|CH4
-Emissions|CO,Emissions|CO,Emissions|CO,Emissions|CO,Emissions|CO,Emissions|CO
-Emissions|CO2,Emissions|CO2,Emissions|CO2,Emissions|CO2,Emissions|CO2,Emissions|CO2
-Emissions|CO2|Biosphere,Emissions|CO2|MAGICC AFOLU,Emissions|CO2|AFOLU,Emissions|CO2|AFOLU,Emissions|CO2|MAGICC AFOLU,Emissions|CO2|AFOLU
-Emissions|CO2|Fossil,Emissions|CO2|MAGICC Fossil and Industrial,Emissions|CO2|Energy and Industrial Processes,Emissions|CO2|Energy and Industrial Processes,Emissions|CO2|MAGICC Fossil and Industrial,Emissions|CO2|Energy and Industrial Processes
-Emissions|HFC125,Emissions|HFC125,Emissions|HFC|HFC125,Emissions|HFC|HFC125,Emissions|F-Gases|HFC|HFC125,Emissions|HFC|HFC125
-Emissions|HFC134a,Emissions|HFC134a,Emissions|HFC|HFC134a,Emissions|HFC|HFC134a,Emissions|F-Gases|HFC|HFC134a,Emissions|HFC|HFC134a
-Emissions|HFC143a,Emissions|HFC143a,Emissions|HFC|HFC143a,Emissions|HFC|HFC143a,Emissions|F-Gases|HFC|HFC143a,Emissions|HFC|HFC143a
-Emissions|HFC152a,Emissions|HFC152a,Emissions|HFC|HFC152a,Emissions|HFC|HFC152a,Emissions|F-Gases|HFC|HFC152a,Emissions|HFC|HFC152a
-Emissions|HFC227ea,Emissions|HFC227ea,Emissions|HFC|HFC227ea,Emissions|HFC|HFC227ea,Emissions|F-Gases|HFC|HFC227ea,Emissions|HFC|HFC227ea
-Emissions|HFC23,Emissions|HFC23,Emissions|HFC|HFC23,Emissions|HFC|HFC23,Emissions|F-Gases|HFC|HFC23,Emissions|HFC|HFC23
-Emissions|HFC236fa,Emissions|HFC236fa,Emissions|HFC|HFC236fa,Emissions|HFC|HFC236fa,Emissions|F-Gases|HFC|HFC236fa,Emissions|HFC|HFC236fa
-Emissions|HFC245fa,Emissions|HFC245fa,Emissions|HFC|HFC245ca,Emissions|HFC|HFC245fa,Emissions|F-Gases|HFC|HFC245fa,Emissions|HFC|HFC245fa
-Emissions|HFC32,Emissions|HFC32,Emissions|HFC|HFC32,Emissions|HFC|HFC32,Emissions|F-Gases|HFC|HFC32,Emissions|HFC|HFC32
-Emissions|HFC365mfc,Emissions|HFC365mfc,Emissions|HFC|HFC365mfc,Emissions|HFC|HFC365mfc,Emissions|F-Gases|HFC|HFC365mfc,Emissions|HFC|HFC365mfc
-Emissions|HFC4310mee,Emissions|HFC4310mee,Emissions|HFC|HFC43-10,Emissions|HFC|HFC43-10,Emissions|F-Gases|HFC|HFC4310mee,Emissions|HFC|HFC43-10
-Emissions|CCl4,Emissions|CCl4,Emissions|CCl4,Emissions|CCl4,Emissions|Montreal Gases|CCl4,Emissions|CCl4
-Emissions|CFC11,Emissions|CFC11,Emissions|CFC11,Emissions|CFC11,Emissions|Montreal Gases|CFC|CFC11,Emissions|CFC11
-Emissions|CFC113,Emissions|CFC113,Emissions|CFC113,Emissions|CFC113,Emissions|Montreal Gases|CFC|CFC113,Emissions|CFC113
-Emissions|CFC114,Emissions|CFC114,Emissions|CFC114,Emissions|CFC114,Emissions|Montreal Gases|CFC|CFC114,Emissions|CFC114
-Emissions|CFC115,Emissions|CFC115,Emissions|CFC115,Emissions|CFC115,Emissions|Montreal Gases|CFC|CFC115,Emissions|CFC115
-Emissions|CFC12,Emissions|CFC12,Emissions|CFC12,Emissions|CFC12,Emissions|Montreal Gases|CFC|CFC12,Emissions|CFC12
-Emissions|CH2Cl2,Emissions|CH2Cl2,Emissions|CH2Cl2,Emissions|CH2Cl2,Emissions|Montreal Gases|CH2Cl2,Emissions|CH2Cl2
-Emissions|CH3Br,Emissions|CH3Br,Emissions|CH3Br,Emissions|CH3Br,Emissions|Montreal Gases|CH3Br,Emissions|CH3Br
-Emissions|CH3CCl3,Emissions|CH3CCl3,Emissions|CH3CCl3,Emissions|CH3CCl3,Emissions|Montreal Gases|CH3CCl3,Emissions|CH3CCl3
-Emissions|CH3Cl,Emissions|CH3Cl,Emissions|CH3Cl,Emissions|CH3Cl,Emissions|Montreal Gases|CH3Cl,Emissions|CH3Cl
-Emissions|CHCl3,Emissions|CHCl3,Emissions|CHCl3,Emissions|CHCl3,Emissions|Montreal Gases|CHCl3,Emissions|CHCl3
-Emissions|HCFC141b,Emissions|HCFC141b,Emissions|HCFC141b,Emissions|HCFC141b,Emissions|Montreal Gases|HCFC141b,Emissions|HCFC141b
-Emissions|HCFC142b,Emissions|HCFC142b,Emissions|HCFC142b,Emissions|HCFC142b,Emissions|Montreal Gases|HCFC142b,Emissions|HCFC142b
-Emissions|HCFC22,Emissions|HCFC22,Emissions|HCFC22,Emissions|HCFC22,Emissions|Montreal Gases|HCFC22,Emissions|HCFC22
-Emissions|Halon1202,Emissions|Halon1202,Emissions|Halon1202,Emissions|Halon1202,Emissions|Montreal Gases|Halon1202,Emissions|Halon1202
-Emissions|Halon1211,Emissions|Halon1211,Emissions|Halon1211,Emissions|Halon1211,Emissions|Montreal Gases|Halon1211,Emissions|Halon1211
-Emissions|Halon1301,Emissions|Halon1301,Emissions|Halon1301,Emissions|Halon1301,Emissions|Montreal Gases|Halon1301,Emissions|Halon1301
-Emissions|Halon2402,Emissions|Halon2402,Emissions|Halon2402,Emissions|Halon2402,Emissions|Montreal Gases|Halon2402,Emissions|Halon2402
-Emissions|N2O,Emissions|N2O,Emissions|N2O,Emissions|N2O,Emissions|N2O,Emissions|N2O
-Emissions|NF3,Emissions|NF3,Emissions|NF3,Emissions|NF3,Emissions|F-Gases|NF3,Emissions|NF3
-Emissions|NH3,Emissions|NH3,Emissions|NH3,Emissions|NH3,Emissions|NH3,Emissions|NH3
-Emissions|NOx,Emissions|NOx,Emissions|NOx,Emissions|NOx,Emissions|NOx,Emissions|NOx
-Emissions|OC,Emissions|OC,Emissions|OC,Emissions|OC,Emissions|OC,Emissions|OC
-Emissions|SF6,Emissions|SF6,Emissions|SF6,Emissions|SF6,Emissions|F-Gases|SF6,Emissions|SF6
-Emissions|SO2F2,Emissions|SO2F2,Emissions|SO2F2,Emissions|SO2F2,Emissions|F-Gases|SO2F2,Emissions|SO2F2
-Emissions|SOx,Emissions|Sulfur,Emissions|Sulfur,Emissions|Sulfur,Emissions|Sulfur,Emissions|Sulfur
-Emissions|NMVOC,Emissions|VOC,Emissions|VOC,Emissions|VOC,Emissions|VOC,Emissions|VOC
-Emissions|cC4F8,Emissions|cC4F8,Emissions|PFC|cC4F8,Emissions|cC4F8,Emissions|F-Gases|PFC|cC4F8,Emissions|PFC|cC4F8
+gcages,openscm_runner,iamc,cmip7_scenariomip,rcmip,rcmip3,ar6_cfc_infilling_db
+Emissions|BC,Emissions|BC,Emissions|BC,Emissions|BC,Emissions|BC,Emissions|BC,Emissions|BC
+Emissions|C2F6,Emissions|C2F6,Emissions|PFC|C2F6,Emissions|C2F6,Emissions|F-Gases|PFC|C2F6,Emissions|F-Gases|PFC|C2F6,Emissions|PFC|C2F6
+Emissions|C3F8,Emissions|C3F8,Emissions|PFC|C3F8,Emissions|C3F8,Emissions|F-Gases|PFC|C3F8,Emissions|F-Gases|PFC|C3F8,Emissions|PFC|C3F8
+Emissions|C4F10,Emissions|C4F10,Emissions|PFC|C4F10,Emissions|C4F10,Emissions|F-Gases|PFC|C4F10,Emissions|F-Gases|PFC|C4F10,Emissions|PFC|C4F10
+Emissions|C5F12,Emissions|C5F12,Emissions|PFC|C5F12,Emissions|C5F12,Emissions|F-Gases|PFC|C5F12,Emissions|F-Gases|PFC|C5F12,Emissions|PFC|C5F12
+Emissions|C6F14,Emissions|C6F14,Emissions|PFC|C6F14,Emissions|C6F14,Emissions|F-Gases|PFC|C6F14,Emissions|F-Gases|PFC|C6F14,Emissions|PFC|C6F14
+Emissions|C7F16,Emissions|C7F16,Emissions|PFC|C7F16,Emissions|C7F16,Emissions|F-Gases|PFC|C7F16,Emissions|F-Gases|PFC|C7F16,Emissions|PFC|C7F16
+Emissions|C8F18,Emissions|C8F18,Emissions|PFC|C8F18,Emissions|C8F18,Emissions|F-Gases|PFC|C8F18,Emissions|F-Gases|PFC|C8F18,Emissions|PFC|C8F18
+Emissions|CF4,Emissions|CF4,Emissions|PFC|CF4,Emissions|CF4,Emissions|F-Gases|PFC|CF4,Emissions|F-Gases|PFC|CF4,Emissions|PFC|CF4
+Emissions|CH4,Emissions|CH4,Emissions|CH4,Emissions|CH4,Emissions|CH4,Emissions|CH4,Emissions|CH4
+Emissions|CO,Emissions|CO,Emissions|CO,Emissions|CO,Emissions|CO,Emissions|CO,Emissions|CO
+Emissions|CO2,Emissions|CO2,Emissions|CO2,Emissions|CO2,Emissions|CO2,Emissions|CO2,Emissions|CO2
+Emissions|CO2|Biosphere,Emissions|CO2|MAGICC AFOLU,Emissions|CO2|AFOLU,Emissions|CO2|AFOLU,Emissions|CO2|MAGICC AFOLU,Emissions|CO2|AFOLU,Emissions|CO2|AFOLU
+Emissions|CO2|Fossil,Emissions|CO2|MAGICC Fossil and Industrial,Emissions|CO2|Energy and Industrial Processes,Emissions|CO2|Energy and Industrial Processes,Emissions|CO2|MAGICC Fossil and Industrial,Emissions|CO2|Fossil and Industrial,Emissions|CO2|Energy and Industrial Processes
+Emissions|HFC125,Emissions|HFC125,Emissions|HFC|HFC125,Emissions|HFC|HFC125,Emissions|F-Gases|HFC|HFC125,Emissions|F-Gases|HFC|HFC125,Emissions|HFC|HFC125
+Emissions|HFC134a,Emissions|HFC134a,Emissions|HFC|HFC134a,Emissions|HFC|HFC134a,Emissions|F-Gases|HFC|HFC134a,Emissions|F-Gases|HFC|HFC134a,Emissions|HFC|HFC134a
+Emissions|HFC143a,Emissions|HFC143a,Emissions|HFC|HFC143a,Emissions|HFC|HFC143a,Emissions|F-Gases|HFC|HFC143a,Emissions|F-Gases|HFC|HFC143a,Emissions|HFC|HFC143a
+Emissions|HFC152a,Emissions|HFC152a,Emissions|HFC|HFC152a,Emissions|HFC|HFC152a,Emissions|F-Gases|HFC|HFC152a,Emissions|F-Gases|HFC|HFC152a,Emissions|HFC|HFC152a
+Emissions|HFC227ea,Emissions|HFC227ea,Emissions|HFC|HFC227ea,Emissions|HFC|HFC227ea,Emissions|F-Gases|HFC|HFC227ea,Emissions|F-Gases|HFC|HFC227ea,Emissions|HFC|HFC227ea
+Emissions|HFC23,Emissions|HFC23,Emissions|HFC|HFC23,Emissions|HFC|HFC23,Emissions|F-Gases|HFC|HFC23,Emissions|F-Gases|HFC|HFC23,Emissions|HFC|HFC23
+Emissions|HFC236fa,Emissions|HFC236fa,Emissions|HFC|HFC236fa,Emissions|HFC|HFC236fa,Emissions|F-Gases|HFC|HFC236fa,Emissions|F-Gases|HFC|HFC236fa,Emissions|HFC|HFC236fa
+Emissions|HFC245fa,Emissions|HFC245fa,Emissions|HFC|HFC245ca,Emissions|HFC|HFC245fa,Emissions|F-Gases|HFC|HFC245fa,Emissions|F-Gases|HFC|HFC245fa,Emissions|HFC|HFC245fa
+Emissions|HFC32,Emissions|HFC32,Emissions|HFC|HFC32,Emissions|HFC|HFC32,Emissions|F-Gases|HFC|HFC32,Emissions|F-Gases|HFC|HFC32,Emissions|HFC|HFC32
+Emissions|HFC365mfc,Emissions|HFC365mfc,Emissions|HFC|HFC365mfc,Emissions|HFC|HFC365mfc,Emissions|F-Gases|HFC|HFC365mfc,Emissions|F-Gases|HFC|HFC365mfc,Emissions|HFC|HFC365mfc
+Emissions|HFC4310mee,Emissions|HFC4310mee,Emissions|HFC|HFC43-10,Emissions|HFC|HFC43-10,Emissions|F-Gases|HFC|HFC4310mee,Emissions|F-Gases|HFC|HFC4310mee,Emissions|HFC|HFC43-10
+Emissions|CCl4,Emissions|CCl4,Emissions|CCl4,Emissions|CCl4,Emissions|Montreal Gases|CCl4,Emissions|Montreal Gases|CCl4,Emissions|CCl4
+Emissions|CFC11,Emissions|CFC11,Emissions|CFC11,Emissions|CFC11,Emissions|Montreal Gases|CFC|CFC11,Emissions|Montreal Gases|CFC|CFC11,Emissions|CFC11
+Emissions|CFC113,Emissions|CFC113,Emissions|CFC113,Emissions|CFC113,Emissions|Montreal Gases|CFC|CFC113,Emissions|Montreal Gases|CFC|CFC113,Emissions|CFC113
+Emissions|CFC114,Emissions|CFC114,Emissions|CFC114,Emissions|CFC114,Emissions|Montreal Gases|CFC|CFC114,Emissions|Montreal Gases|CFC|CFC114,Emissions|CFC114
+Emissions|CFC115,Emissions|CFC115,Emissions|CFC115,Emissions|CFC115,Emissions|Montreal Gases|CFC|CFC115,Emissions|Montreal Gases|CFC|CFC115,Emissions|CFC115
+Emissions|CFC12,Emissions|CFC12,Emissions|CFC12,Emissions|CFC12,Emissions|Montreal Gases|CFC|CFC12,Emissions|Montreal Gases|CFC|CFC12,Emissions|CFC12
+Emissions|CH2Cl2,Emissions|CH2Cl2,Emissions|CH2Cl2,Emissions|CH2Cl2,Emissions|Montreal Gases|CH2Cl2,Emissions|Montreal Gases|CH2Cl2,Emissions|CH2Cl2
+Emissions|CH3Br,Emissions|CH3Br,Emissions|CH3Br,Emissions|CH3Br,Emissions|Montreal Gases|CH3Br,Emissions|Montreal Gases|CH3Br,Emissions|CH3Br
+Emissions|CH3CCl3,Emissions|CH3CCl3,Emissions|CH3CCl3,Emissions|CH3CCl3,Emissions|Montreal Gases|CH3CCl3,Emissions|Montreal Gases|CH3CCl3,Emissions|CH3CCl3
+Emissions|CH3Cl,Emissions|CH3Cl,Emissions|CH3Cl,Emissions|CH3Cl,Emissions|Montreal Gases|CH3Cl,Emissions|Montreal Gases|CH3Cl,Emissions|CH3Cl
+Emissions|CHCl3,Emissions|CHCl3,Emissions|CHCl3,Emissions|CHCl3,Emissions|Montreal Gases|CHCl3,Emissions|Montreal Gases|CHCl3,Emissions|CHCl3
+Emissions|HCFC141b,Emissions|HCFC141b,Emissions|HCFC141b,Emissions|HCFC141b,Emissions|Montreal Gases|HCFC141b,Emissions|Montreal Gases|HCFC141b,Emissions|HCFC141b
+Emissions|HCFC142b,Emissions|HCFC142b,Emissions|HCFC142b,Emissions|HCFC142b,Emissions|Montreal Gases|HCFC142b,Emissions|Montreal Gases|HCFC142b,Emissions|HCFC142b
+Emissions|HCFC22,Emissions|HCFC22,Emissions|HCFC22,Emissions|HCFC22,Emissions|Montreal Gases|HCFC22,Emissions|Montreal Gases|HCFC22,Emissions|HCFC22
+Emissions|Halon1202,Emissions|Halon1202,Emissions|Halon1202,Emissions|Halon1202,Emissions|Montreal Gases|Halon1202,Emissions|Montreal Gases|Halon1202,Emissions|Halon1202
+Emissions|Halon1211,Emissions|Halon1211,Emissions|Halon1211,Emissions|Halon1211,Emissions|Montreal Gases|Halon1211,Emissions|Montreal Gases|Halon1211,Emissions|Halon1211
+Emissions|Halon1301,Emissions|Halon1301,Emissions|Halon1301,Emissions|Halon1301,Emissions|Montreal Gases|Halon1301,Emissions|Montreal Gases|Halon1301,Emissions|Halon1301
+Emissions|Halon2402,Emissions|Halon2402,Emissions|Halon2402,Emissions|Halon2402,Emissions|Montreal Gases|Halon2402,Emissions|Montreal Gases|Halon2402,Emissions|Halon2402
+Emissions|N2O,Emissions|N2O,Emissions|N2O,Emissions|N2O,Emissions|N2O,Emissions|N2O,Emissions|N2O
+Emissions|NF3,Emissions|NF3,Emissions|NF3,Emissions|NF3,Emissions|F-Gases|NF3,Emissions|F-Gases|NF3,Emissions|NF3
+Emissions|NH3,Emissions|NH3,Emissions|NH3,Emissions|NH3,Emissions|NH3,Emissions|NH3,Emissions|NH3
+Emissions|NOx,Emissions|NOx,Emissions|NOx,Emissions|NOx,Emissions|NOx,Emissions|NOx,Emissions|NOx
+Emissions|OC,Emissions|OC,Emissions|OC,Emissions|OC,Emissions|OC,Emissions|OC,Emissions|OC
+Emissions|SF6,Emissions|SF6,Emissions|SF6,Emissions|SF6,Emissions|F-Gases|SF6,Emissions|F-Gases|SF6,Emissions|SF6
+Emissions|SO2F2,Emissions|SO2F2,Emissions|SO2F2,Emissions|SO2F2,Emissions|F-Gases|SO2F2,Emissions|F-Gases|SO2F2,Emissions|SO2F2
+Emissions|SOx,Emissions|Sulfur,Emissions|Sulfur,Emissions|Sulfur,Emissions|Sulfur,Emissions|Sulfur,Emissions|Sulfur
+Emissions|NMVOC,Emissions|VOC,Emissions|VOC,Emissions|VOC,Emissions|VOC,Emissions|VOC,Emissions|VOC
+Emissions|cC4F8,Emissions|cC4F8,Emissions|PFC|cC4F8,Emissions|cC4F8,Emissions|F-Gases|PFC|cC4F8,Emissions|F-Gases|PFC|cC4F8,Emissions|PFC|cC4F8


### PR DESCRIPTION
## Description

Added a new column to the emissions_variables.csv mapping with the values from RCMIP3. The only difference between previous values and RCMIP3's is the deletion of the "MAGICC" qualifier in the two disaggregated CO2 variables:  "Emissions|CO2|MAGICC Fossil and Industrial" and "Emissions|CO2|MAGICC AFOLU".

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added -> Not familiar with the testing suite, so unsure if this requires any modifications. Happy to add some tests if pointed to the relevant bit in the testing codebank.
- [x] Documentation added (where applicable) -> Not applicable?
- [x] Changelog item added to `changelog/` -> Don't think it's an user-facing change, which the CHANGELOG suggests is the only type of changes that should go into the CHANGELOG.
