### PR TITLE
Loosen SCI whole-pipeline quantile tolerance to 1e-4

### DIFF
--- a/changelog/68.fix.md
+++ b/changelog/68.fix.md
@@ -1,0 +1,2 @@
+Loosened the SCI whole-pipeline post-processing quantile regression tolerance to `1e-4`,
+matching the `scm_results` comparison and the CMIP7 whole-pipeline test to fix failures on Python 3.10 and macOS.

--- a/tests/regression/sci_june_2026/test_regression_sci_whole_pipeline.py
+++ b/tests/regression/sci_june_2026/test_regression_sci_whole_pipeline.py
@@ -238,7 +238,7 @@ def test_whole_pipeline(model, scenario, monkeypatch):
     assert_frame_equal(
         processed_quantiles,
         exp_quantiles,
-        rtol=1e-6,
+        rtol=1e-4,
     )
 
     # Loading and categories


### PR DESCRIPTION
## Description
Loosened the SCI whole-pipeline post-processing quantile regression tolerance to `1e-4`, matching the `scm_results` comparison and the CMIP7 whole-pipeline test to fix failures on Python 3.10 and macOS.

## Checklist

Please confirm that this pull request has done the following:

- [ ] ~Tests added~
- [ ] ~Documentation added (where applicable)~
- [x] Changelog item added to `changelog/`
